### PR TITLE
Migrate plugin to npe2

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -3,7 +3,7 @@
 
 name: tests
 
-on: 
+on:
   push:
     branches:
       - master
@@ -46,7 +46,7 @@ jobs:
       - name: Install Windows OpenGL
         if: runner.os == 'Windows'
         run: |
-          git clone --depth 1 git://github.com/pyvista/gl-ci-helpers.git
+          git clone --depth 1 https://github.com/pyvista/gl-ci-helpers.git
           powershell gl-ci-helpers/appveyor/install_opengl.ps1
 
       # note: if you need dependencies from conda, considering using
@@ -69,7 +69,7 @@ jobs:
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
-    # and requires that you have put your twine API key in your 
+    # and requires that you have put your twine API key in your
     # github secrets (see readme for details)
     needs: [test]
     runs-on: ubuntu-latest

--- a/napari_stl_exporter/__init__.py
+++ b/napari_stl_exporter/__init__.py
@@ -1,4 +1,3 @@
-
 __version__ = "0.0.6"
 
-from ._writer import napari_get_writer, napari_write_labels
+from ._writer import napari_write_labels

--- a/napari_stl_exporter/__init__.py
+++ b/napari_stl_exporter/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.6"
+__version__ = "0.0.7"
 
 from ._writer import napari_write_labels

--- a/napari_stl_exporter/_writer.py
+++ b/napari_stl_exporter/_writer.py
@@ -1,48 +1,24 @@
-"""
-This module is an example of a barebones writer plugin for napari
-
-It implements the ``napari_get_writer`` and ``napari_write_image`` hook specifications.
-see: https://napari.org/docs/dev/plugins/hook_specifications.html
-
-Replace code below according to your needs
-"""
-
 import os
 from skimage import measure
-
-from napari_plugin_engine import napari_hook_implementation
-from napari.types import LabelsData
 import vedo
+
+from napari.types import LabelsData
+from typing import Any, Optional
+
 
 supported_layers = ['labels']
 supported_formats = ['.stl', '.ply']
 
-@napari_hook_implementation
-def napari_get_writer(path, layer_types):
-    
-    # Check that only supported layers have been passed
-    for lt in set(layer_types):
-        if lt not in supported_layers:
-            return None
+def napari_write_labels(path: str, data: Any, meta: dict) -> Optional[str]:
 
     file_ext = os.path.splitext(path)[1]
-    if isinstance(path, str) and file_ext in supported_formats:
-        return napari_write_labels
-    else:
-        return None
-
-@napari_hook_implementation
-def napari_write_labels(path:str, data: LabelsData, meta) -> str:
-
-    file_ext = os.path.splitext(path)[1]
-    print(file_ext)
     if isinstance(path, str) and file_ext in supported_formats:
 
         mesh = _labels_to_mesh(data)
         vedo.write(mesh, path)
 
         return path
-    
+
     else:
         return None
 

--- a/napari_stl_exporter/napari.yaml
+++ b/napari_stl_exporter/napari.yaml
@@ -1,0 +1,13 @@
+name: napari-stl-exporter
+schema_version: 0.1.0
+contributions:
+  commands:
+  - id: napari-stl-exporter.write_labels
+    title: Write Labels
+    python_name: napari_stl_exporter._writer:napari_write_labels
+  writers:
+  - command: napari-stl-exporter.write_labels
+    layer_types:
+    - labels
+    filename_extensions: [".stl", ".ply"]
+    display_name: labels

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,37 +3,39 @@ name = napari-stl-exporter
 version = 0.0.6
 author = Johannes Müller
 author_email = johannes_richard.mueller@tu-dresden.de
-
 license = BSD-3-Clause
 description = Exports label images to 3D-printable stl files.
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/jo-mueller/napari-stl-exporter.git
-classifiers =
-    Development Status :: 3 - Alpha 
-    Intended Audience :: Developers
-    Framework :: napari
-    Topic :: Software Development :: Testing
-    Programming Language :: Python
-    Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
-    Programming Language :: Python :: 3.9
-    Operating System :: OS Independent
-    License :: OSI Approved :: BSD License
-
+classifiers = 
+	Development Status :: 3 - Alpha
+	Intended Audience :: Developers
+	Framework :: napari
+	Topic :: Software Development :: Testing
+	Programming Language :: Python
+	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.7
+	Programming Language :: Python :: 3.8
+	Programming Language :: Python :: 3.9
+	Operating System :: OS Independent
+	License :: OSI Approved :: BSD License
 
 [options]
 packages = find:
 python_requires = >=3.7
-
 # add your package requirements here
-install_requires =
-    napari-plugin-engine>=0.1.4
-    numpy
-    scikit-image
-    vedo
+install_requires = 
+	napari-plugin-engine>=0.1.4
+	numpy
+	scikit-image
+	vedo
+include_package_data = True
 
 [options.entry_points]
-napari.plugin = 
-    stl = napari_stl_exporter
+napari.manifest = 
+	napari-stl-exporter = napari_stl_exporter:napari.yaml
+
+[options.package_data]
+napari_stl_exporter = napari.yaml
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = napari-stl-exporter
-version = 0.0.6
+version = 0.0.7
 author = Johannes Müller
 author_email = johannes_richard.mueller@tu-dresden.de
 license = BSD-3-Clause
@@ -8,7 +8,7 @@ description = Exports label images to 3D-printable stl files.
 long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/jo-mueller/napari-stl-exporter.git
-classifiers = 
+classifiers =
 	Development Status :: 3 - Alpha
 	Intended Audience :: Developers
 	Framework :: napari
@@ -25,7 +25,7 @@ classifiers =
 packages = find:
 python_requires = >=3.7
 # add your package requirements here
-install_requires = 
+install_requires =
 	napari-plugin-engine>=0.1.4
 	numpy
 	scikit-image
@@ -33,9 +33,8 @@ install_requires =
 include_package_data = True
 
 [options.entry_points]
-napari.manifest = 
+napari.manifest =
 	napari-stl-exporter = napari_stl_exporter:napari.yaml
 
 [options.package_data]
 napari_stl_exporter = napari.yaml
-


### PR DESCRIPTION
Use the new napari plugin engine 2 since the npe1 has been designated as deprecated.