### PR TITLE
Add obj support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,32 +6,30 @@
 [![tests](https://github.com/jo-mueller/napari-stl-exporter/workflows/tests/badge.svg)](https://github.com/jo-mueller/napari-stl-exporter/actions)
 [![codecov](https://codecov.io/gh/jo-mueller/napari-stl-exporter/branch/main/graph/badge.svg?token=9zctLzazD9)](https://codecov.io/gh/jo-mueller/napari-stl-exporter)
 
-This plugin allows to convert data in Napari to 3D-printable [*.stl*, *.ply*] files using various algorithms. The generated files can then be read by common 3D-printing slicer programs (see below).
+This plugin allows to import and export surface data in Napari to common file formats. The generated file formats can be read by other common applications, and - in particular - allow *3D-printing*.
 
 <img src="https://github.com/jo-mueller/napari-stl-exporter/blob/main/doc/model_and_printed_model.png" width=80% height=80%>
 
 ## Usage
 This section explains which data can be written with the napari-stl-exported and how you can do so.
 
+### Supported file formats:
+Currently supported file formats for export include and rely on the [vedo io API](https://vedo.embl.es/autodocs/content/vedo/io.html#vedo.io).
+* *.stl*: [Standard triangle language](https://en.wikipedia.org/wiki/STL_%28file_format%29)
+* *.ply*: [Polygon file format](https://en.wikipedia.org/wiki/PLY_(file_format))
+* *.obj*: [Wavefront object](https://en.wikipedia.org/wiki/Wavefront_.obj_file)
+
 ### Supported Napari layers:
 
 Currently supported Napari layer types are:
-* Label layers: The label data is converted to surface data using the [marching cubes algorithm](https://scikit-image.org/docs/dev/api/skimage.measure.html#skimage.measure.marching_cubes) implemented in [scikit-image](https://scikit-image.org/) and is then exported using [Vedo](https://vedo.embl.es/).
-* Surface layers: Surface data can be natively exported with the [Vedo](https://vedo.embl.es/) library.
+* [Surface layers](https://napari.org/howtos/layers/surface.html)
+* [Label layers](https://napari.org/howtos/layers/labels.html): The label data is converted to surface data under the hood using the [marching cubes algorithm](https://scikit-image.org/docs/dev/api/skimage.measure.html#skimage.measure.marching_cubes) implemented in [scikit-image](https://scikit-image.org/) and is then exported using [Vedo](https://vedo.embl.es/). Warning: This can be slow for large image data!
 
-### Supported file formats:
-Currently supported file formats for export include:
-* *.stl*: Common data format for 3D printing, can be read by common 3D slicer programs (see below)
-* *.ply*: Common data storage format for surfaces, needs to be converted to *.stl* either with this plugin or with suitable software (e.g., Blender).
+### Import/export
 
-### Preparing data
-- **Interactively**: You can create sample label/surface data for export using the built-in functions as shown here:
+**Interactively:** To export the data, simply save the selected layer with `File > Save Selected Layer(s)` and specify the file ending to be `some_file.[file_ending]`, for supported file types, see above. Similarly, supported file types can be imported into Napari with `File > `
 
-<img src="https://github.com/jo-mueller/napari-stl-exporter/blob/main/doc/1_sample_data.png" width=45% height=45%>
-
-To export the data, simply save the selected layer with `File > Save Selected Layer(s)` and specify the file ending to be `some_file.stl` or `some_file.ply`.
-
-- **Programmatically**: A [Napari Label layer](https://napari.org/api/napari.layers.Labels.html) can be added to the viewer as described in the [napari reference](https://napari.org/gallery/add_labels.html?highlight=add_labels) with this code snippet:
+**From code**: A [Napari Label layer](https://napari.org/api/napari.layers.Labels.html) can be added to the viewer as described in the [napari reference](https://napari.org/gallery/add_labels.html?highlight=add_labels) with this code snippet:
 
 ```python
 import napari
@@ -47,6 +45,20 @@ label_layer = viewer.add_labels(data, name='3D object')
 
 # save the layer as 3D printable file to disc
 napari.save_layers(r'/some/path/test.stl', [label_layer])
+```
+
+### Sample data
+You can create sample label/surface data for export using the built-in functions as shown here:
+
+<img src="https://github.com/jo-mueller/napari-stl-exporter/blob/main/doc/1_sample_data.png" width=45% height=45%>
+
+...or from code with
+
+```Python
+import napari_stl_exporter
+
+pyramid = napari_stl_exporter.make_pyramid_surface()
+
 ```
 
 ### 3D-printing

--- a/src/napari_stl_exporter/__init__.py
+++ b/src/napari_stl_exporter/__init__.py
@@ -1,5 +1,5 @@
 __version__ = "0.0.10"
 
-from ._writer import napari_write_labels, napari_write_surface
+from ._writer import napari_write_labels, napari_write_surfaces
 from ._reader import napari_import_surface
 from ._test_data import make_pyramid_label, make_pyramid_surface

--- a/src/napari_stl_exporter/_reader.py
+++ b/src/napari_stl_exporter/_reader.py
@@ -1,12 +1,23 @@
 # -*- coding: utf-8 -*-
-from napari.types import SurfaceData
+from napari.types import LayerDataTuple
 import os
 import vedo
 import numpy as np
+from typing import Optional, List
 
 supported_formats = ['.stl', '.ply', '.obj']
 
-def napari_import_surface(path: str) -> SurfaceData:
+def get_reader(path: str) -> Optional[callable]:
+    # Taken from https://napari.org/plugins/guides.html
+
+    file_ext = os.path.splitext(path)[1]
+    if isinstance(path, str) and file_ext in supported_formats:
+        return napari_import_surface
+
+    # otherwise we return None.
+    return None
+
+def napari_import_surface(path: str) -> List[LayerDataTuple]:
     """
     Read supported surface files using the vedo io functionality.
 
@@ -19,10 +30,6 @@ def napari_import_surface(path: str) -> SurfaceData:
     SurfaceData
 
     """
-    file_ext = os.path.splitext(path)[1]
-    if file_ext in supported_formats:
-
-        mesh = vedo.io.load(path, unpack=True, force=False)
-        mesh = (mesh.points(), np.asarray(mesh.faces()))
-
-        return mesh
+    mesh = vedo.io.load(path, unpack=True, force=False)
+    _mesh = [mesh.points(), np.asarray(mesh.faces())]
+    return [tuple([_mesh, {}, 'surface'])]

--- a/src/napari_stl_exporter/_reader.py
+++ b/src/napari_stl_exporter/_reader.py
@@ -4,7 +4,7 @@ import os
 import vedo
 import numpy as np
 
-supported_formats = ['.stl', '.ply']
+supported_formats = ['.stl', '.ply', '.obj']
 
 def napari_import_surface(path: str) -> SurfaceData:
     """

--- a/src/napari_stl_exporter/_tests/test_writer_and_readers.py
+++ b/src/napari_stl_exporter/_tests/test_writer_and_readers.py
@@ -1,4 +1,5 @@
-from napari_stl_exporter._writer import _labels_to_mesh, napari_write_labels, napari_write_surface
+from napari_stl_exporter._writer import _labels_to_mesh, napari_write_labels, napari_write_surfaces
+from napari_stl_exporter import napari_import_surface
 from napari_stl_exporter._test_data import make_pyramid_label, make_pyramid_surface
 import numpy as np
 import os
@@ -29,7 +30,7 @@ def test_writer(tmpdir):
 
     for ext in supported_formats:
         pth = os.path.join(str(tmpdir), "test_export" + ext)
-        stl_file = napari_write_surface(pth, surf, None)
+        stl_file = napari_write_surfaces(pth, surf, None)
         assert os.path.exists(pth)
         assert stl_file is not None
 
@@ -61,10 +62,9 @@ def test_reader(make_napari_viewer, tmpdir):
     viewer = make_napari_viewer()
 
     for ext in supported_formats:
-        napari_stl_exporter.napari_write_surface(os.path.join(tmpdir, 'test' + ext), pyramid, None)
-        pyramid = napari_stl_exporter.napari_import_surface(os.path.join(tmpdir, 'test' + ext))
-        viewer.add_surface(pyramid)
-
+        napari_write_surfaces(os.path.join(tmpdir, 'test' + ext), pyramid, None)
+        _pyramid = napari_import_surface(os.path.join(tmpdir, 'test' + ext))[0]
+        viewer.add_surface(_pyramid[0], **_pyramid[1])
 
 
 if __name__ == '__main__':

--- a/src/napari_stl_exporter/_tests/test_writer_and_readers.py
+++ b/src/napari_stl_exporter/_tests/test_writer_and_readers.py
@@ -62,9 +62,15 @@ def test_reader(make_napari_viewer, tmpdir):
     viewer = make_napari_viewer()
 
     for ext in supported_formats:
-        napari_write_surfaces(os.path.join(tmpdir, 'test' + ext), pyramid, None)
-        _pyramid = napari_import_surface(os.path.join(tmpdir, 'test' + ext))[0]
+        path = os.path.join(tmpdir, 'test' + ext)
+        napari_write_surfaces(path, pyramid, None)
+        _pyramid = napari_import_surface(path)[0]
         viewer.add_surface(_pyramid[0], **_pyramid[1])
+
+        # make sure that a reader is found
+        reader = napari_stl_exporter._reader.get_reader(path)
+        data = reader(path)
+        assert data is not None
 
 
 if __name__ == '__main__':

--- a/src/napari_stl_exporter/_tests/test_writer_and_readers.py
+++ b/src/napari_stl_exporter/_tests/test_writer_and_readers.py
@@ -3,6 +3,8 @@ from napari_stl_exporter._test_data import make_pyramid_label, make_pyramid_surf
 import numpy as np
 import os
 
+supported_formats = ['.stl', '.ply', '.obj']
+
 def test_label_conversion():
     import vedo
     label_image = np.zeros((100, 100, 100))
@@ -17,27 +19,19 @@ def test_writer(tmpdir):
     label_image = np.zeros((100, 100, 100))
     label_image[25:75, 25:75, 25:75] = 1
 
-    pth = os.path.join(str(tmpdir), "test_export.stl")
-    stl_file = napari_write_labels(pth, label_image, None)
-    assert os.path.exists(pth)
-    assert stl_file is not None
-
-    pth = os.path.join(str(tmpdir), "test_export.ply")
-    ply_file = napari_write_labels(pth, label_image, None)
-    assert os.path.exists(pth)
-    assert ply_file is not None
+    for ext in supported_formats:
+        pth = os.path.join(str(tmpdir), "test_export" + ext)
+        stl_file = napari_write_labels(pth, label_image, None)
+        assert os.path.exists(pth)
+        assert stl_file is not None
 
     surf = measure.marching_cubes(label_image)
 
-    pth = os.path.join(str(tmpdir), "test_export.ply")
-    stl_file = napari_write_surface(pth, surf, None)
-    assert os.path.exists(pth)
-    assert stl_file is not None
-
-    pth = os.path.join(str(tmpdir), "test_export.stl")
-    stl_file = napari_write_surface(pth, surf, None)
-    assert os.path.exists(pth)
-    assert stl_file is not None
+    for ext in supported_formats:
+        pth = os.path.join(str(tmpdir), "test_export" + ext)
+        stl_file = napari_write_surface(pth, surf, None)
+        assert os.path.exists(pth)
+        assert stl_file is not None
 
 def test_writer_viewer(make_napari_viewer, tmpdir):
     import napari
@@ -64,12 +58,12 @@ def test_reader(make_napari_viewer, tmpdir):
     import napari_stl_exporter
 
     pyramid = napari_stl_exporter.make_pyramid_surface()[0][0]
-
-    napari_stl_exporter.napari_write_surface(os.path.join(tmpdir, 'test.stl'), pyramid, None)
-    pyramid = napari_stl_exporter.napari_import_surface(os.path.join(tmpdir, 'test.stl'))
-
     viewer = make_napari_viewer()
-    viewer.add_surface(pyramid)
+
+    for ext in supported_formats:
+        napari_stl_exporter.napari_write_surface(os.path.join(tmpdir, 'test' + ext), pyramid, None)
+        pyramid = napari_stl_exporter.napari_import_surface(os.path.join(tmpdir, 'test' + ext))
+        viewer.add_surface(pyramid)
 
 
 

--- a/src/napari_stl_exporter/_writer.py
+++ b/src/napari_stl_exporter/_writer.py
@@ -9,7 +9,7 @@ from typing import Optional
 supported_layers = ['labels']
 supported_formats = ['.stl', '.ply', '.obj']
 
-def napari_write_surface(path: str, data: SurfaceData, meta: dict
+def napari_write_surfaces(path: str, data: SurfaceData, meta: dict
                          ) -> Optional[str]:
     file_ext = os.path.splitext(path)[1]
     if file_ext in supported_formats:

--- a/src/napari_stl_exporter/_writer.py
+++ b/src/napari_stl_exporter/_writer.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 
 supported_layers = ['labels']
-supported_formats = ['.stl', '.ply']
+supported_formats = ['.stl', '.ply', '.obj']
 
 def napari_write_surface(path: str, data: SurfaceData, meta: dict
                          ) -> Optional[str]:

--- a/src/napari_stl_exporter/napari.yaml
+++ b/src/napari_stl_exporter/napari.yaml
@@ -8,7 +8,7 @@ contributions:
 
     - id: napari-stl-exporter.write_surface
       title: Write Surface
-      python_name: napari_stl_exporter._writer:napari_write_surface
+      python_name: napari_stl_exporter._writer:napari_write_surfaces
 
     - id: napari-stl-exporter.make_pyramid_label
       title: Create a label image of a pyramid
@@ -20,7 +20,7 @@ contributions:
 
     - id: napari-stl-exporter.import_surface
       title: Read surface data from supported file types
-      python_name: napari_stl_exporter._reader:napari_import_surface
+      python_name: napari_stl_exporter._reader:get_reader
 
     sample_data:
     - command: napari-stl-exporter.make_pyramid_label
@@ -46,4 +46,7 @@ contributions:
     readers:
     - command: napari-stl-exporter.import_surface
       accepts_directories: false
-      filename_patterns: ["*.stl", "*.ply", "*.obj"]
+      filename_patterns:
+      - "*.stl"
+      - "*.ply"
+      - "*.obj"

--- a/src/napari_stl_exporter/napari.yaml
+++ b/src/napari_stl_exporter/napari.yaml
@@ -34,16 +34,16 @@ contributions:
     - command: napari-stl-exporter.write_labels
       layer_types:
       - labels
-      filename_extensions: [".stl", ".ply"]
+      filename_extensions: [".stl", ".ply", ".obj"]
       display_name: labels
 
     - command: napari-stl-exporter.write_surface
       layer_types:
       - surface
-      filename_extensions: [".stl", ".ply"]
+      filename_extensions: [".stl", ".ply", ".obj"]
       display_name: surface
 
     readers:
     - command: napari-stl-exporter.import_surface
       accepts_directories: false
-      filename_patterns: ["*.stl", "*.ply"]
+      filename_patterns: ["*.stl", "*.ply", "*.obj"]


### PR DESCRIPTION
napari-stl-exporter now allows to import/export obj file format. Tagging #27  to keep track.