### PR TITLE
move project_urls to standard location

### DIFF
--- a/.napari/config.yml
+++ b/.napari/config.yml
@@ -1,9 +1,0 @@
-# .napari/config.yml
-# ...
-project_urls:
-    Project Site: https://github.com/jo-mueller/napari-stl-exporter
-    Report Issues: https://github.com/jo-mueller/napari-stl-exporter/issues
-    Documentation: https://pypi.org/project/napari-stl-exporter/
-    User Support: https://github.com/jo-mueller/napari-stl-exporter/issues
-    Twitter: https://twitter.com/jm_mightypirate
-# ...

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,12 @@ classifiers =
 	Programming Language :: Python :: 3.9
 	Operating System :: OS Independent
 	License :: OSI Approved :: BSD License
+project_urls = 
+    Project Site = https://github.com/jo-mueller/napari-stl-exporter
+    Report Issues = https://github.com/jo-mueller/napari-stl-exporter/issues
+    Documentation = https://pypi.org/project/napari-stl-exporter/
+    User Support = https://github.com/jo-mueller/napari-stl-exporter/issues
+    Twitter = https://twitter.com/jm_mightypirate
 
 [options]
 packages = find:


### PR DESCRIPTION
Hello, in going through some napari plugins with missing metadata, I found your urls in the wrong place.  This fixes that.  Note that you can use `.napari/config.yaml` if you'd like to _override_ how your page appears on the hub, but you should minimally populate the official sources for  [standard metadata](https://packaging.python.org/en/latest/specifications/core-metadata/) 